### PR TITLE
update pGroup after realloc

### DIFF
--- a/progmgr/group.c
+++ b/progmgr/group.c
@@ -266,8 +266,11 @@ PITEM CreateItem(_In_ HWND hWndGroup, _In_ PITEM pi)
 	if (_msize(pGroup) != CalculateGroupMemory(pGroup, 1))
 	{
 		// if we reallocate memory then send the new pointer in
-		if (realloc(pGroup, CalculateGroupMemory(pGroup, 1)) != NULL)
+		PGROUP pNewGroup = realloc(pGroup, CalculateGroupMemory(pGroup, 1));
+		if (pNewGroup != NULL) {
+			pGroup = pNewGroup;
 			SetWindowLongPtr(hWndGroup, GWLP_USERDATA, (LONG_PTR)pGroup);
+		}
 	}
 
 	// add the item


### PR DESCRIPTION
If realloc succeeds, it returns the pointer to new memory (which may be different from old memory).
Right now the new memory pointer is ignored and the USERDATA is set to the old memory (that would be freed):
https://github.com/Vortesys/Program-Manager-II/blob/39229500f6a27ef9b033f32396a5cacb9e0f4a5a/progmgr/group.c#L268-L270